### PR TITLE
Reviewer Alex - Support vbuckets

### DIFF
--- a/libmemcached-1.0/storage.h
+++ b/libmemcached-1.0/storage.h
@@ -1,5 +1,5 @@
 /*  vim:expandtab:shiftwidth=2:tabstop=2:smarttab:
- * 
+ *
  *  Libmemcached library
  *
  *  Copyright (C) 2011 Data Differential, http://datadifferential.com/
@@ -48,10 +48,19 @@ memcached_return_t memcached_set(memcached_st *ptr, const char *key, size_t key_
                                  time_t expiration,
                                  uint32_t  flags);
 LIBMEMCACHED_API
+memcached_return_t memcached_set_vb(memcached_st *ptr, const char *key, size_t key_length, const uint16_t vbucket,
+                                    const char *value, size_t value_length,
+                                    time_t expiration,
+                                    uint32_t  flags);
+LIBMEMCACHED_API
 memcached_return_t memcached_add(memcached_st *ptr, const char *key, size_t key_length,
                                  const char *value, size_t value_length,
                                  time_t expiration,
                                  uint32_t  flags);
+memcached_return_t memcached_add_vb(memcached_st *ptr, const char *key, size_t key_length, const uint16_t vbucket,
+                                    const char *value, size_t value_length,
+                                    time_t expiration,
+                                    uint32_t  flags);
 LIBMEMCACHED_API
 memcached_return_t memcached_replace(memcached_st *ptr, const char *key, size_t key_length,
                                      const char *value, size_t value_length,
@@ -76,6 +85,14 @@ memcached_return_t memcached_cas(memcached_st *ptr,
                                  time_t expiration,
                                  uint32_t flags,
                                  uint64_t cas);
+LIBMEMCACHED_API
+memcached_return_t memcached_cas_vb(memcached_st *ptr,
+                                    const char *key, size_t key_length,
+                                    const uint16_t vbucket,
+                                    const char *value, size_t value_length,
+                                    time_t expiration,
+                                    uint32_t flags,
+                                    uint64_t cas);
 
 LIBMEMCACHED_API
 memcached_return_t memcached_set_by_key(memcached_st *ptr,

--- a/libmemcached/fetch.cc
+++ b/libmemcached/fetch.cc
@@ -202,7 +202,8 @@ memcached_result_st *memcached_fetch_result(memcached_st *ptr,
     {
       continue;
     }
-    else if (*error == MEMCACHED_CONNECTION_FAILURE)
+    else if ((*error == MEMCACHED_CONNECTION_FAILURE) ||
+             (*error == MEMCACHED_TIMEOUT))
     {
       connection_failures = true;
       continue;


### PR DESCRIPTION
Alex, if you've not got time to look at these this sprint, please push back.

This adds support for passing vbucket IDs on SET-like operations over the binary API (the ASCII API has no support for vbuckets).  I didn't just extend the existing functions as older Memcached servers should reject requests where the vbucket section of the request is non-zero (and it makes it easier to submit the change upstream, where they won't want back-compatibility breaking changes).