### PR TITLE
Reviewer Alex - Use GETK for mget with a single key

### DIFF
--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -393,7 +393,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
                                          size_t number_of_keys)
 {
   return memcached_mget_by_key_real(ptr, group_key, group_key_length, keys,
-                                    key_length, number_of_keys, (number_of_keys == 1));
+                                    key_length, number_of_keys, false);
 }
 
 memcached_return_t memcached_mget_execute(memcached_st *ptr,

--- a/libmemcached/get.cc
+++ b/libmemcached/get.cc
@@ -393,7 +393,7 @@ memcached_return_t memcached_mget_by_key(memcached_st *ptr,
                                          size_t number_of_keys)
 {
   return memcached_mget_by_key_real(ptr, group_key, group_key_length, keys,
-                                    key_length, number_of_keys, true);
+                                    key_length, number_of_keys, (number_of_keys == 1));
 }
 
 memcached_return_t memcached_mget_execute(memcached_st *ptr,


### PR DESCRIPTION
This prevents having to time-out the GETKQ (that we would otherwise do) in the case where the key is absent on the server.  Tested live with the live test framework.