### PR TITLE
[Reviewer: Ellie] Bison 3 fix

### DIFF
--- a/libmemcached/csl/parser.am
+++ b/libmemcached/csl/parser.am
@@ -1,7 +1,7 @@
 # vim:ft=automake
 # included from Top Level Makefile.am
 # All paths should be given relative to the root
- 
+
 EXTRA_DIST+= libmemcached/csl/parser.yy
 EXTRA_DIST+= libmemcached/csl/scanner.l
 
@@ -9,7 +9,7 @@ libmemcached/csl/parser.h: libmemcached/csl/parser.cc
 
 # This makefile is incompatible with new versions of bison. This means that running the rules for parser.cc or scanner.cc
 # will break the build. Instead of just removing the rule, we force make to use low resolution (i.e nearest second)
-# timestmaps. This means that the targets are not regenerated after an initial checkout, but they are if someone
+# timestamps. This means that the targets are not regenerated after an initial checkout, but they are if someone
 # actually changes any of the dependencies.
 
 .LOW_RESOLUTION_TIME: libmemcached/csl/parser.cc

--- a/libmemcached/csl/parser.am
+++ b/libmemcached/csl/parser.am
@@ -7,10 +7,10 @@ EXTRA_DIST+= libmemcached/csl/scanner.l
 
 libmemcached/csl/parser.h: libmemcached/csl/parser.cc
 
-# This makefile is incompatible with new versions of bison. This means that running the rules for parser.cc or scanner.cc 
-# will break the build. Instead of just removing the rule, we force make to use low resolution (i.e nearest second) 
-# timestmaps. This means that the targets are not regenerated after an initial checkout, but they are if someone 
-# actually changes any of the dependencies. 
+# This makefile is incompatible with new versions of bison. This means that running the rules for parser.cc or scanner.cc
+# will break the build. Instead of just removing the rule, we force make to use low resolution (i.e nearest second)
+# timestmaps. This means that the targets are not regenerated after an initial checkout, but they are if someone
+# actually changes any of the dependencies.
 
 .LOW_RESOLUTION_TIME: libmemcached/csl/parser.cc
 libmemcached/csl/parser.cc: libmemcached/csl/parser.yy libmemcached/csl/scanner.l libmemcached/csl/scanner.h
@@ -18,6 +18,6 @@ libmemcached/csl/parser.cc: libmemcached/csl/parser.yy libmemcached/csl/scanner.
 
 libmemcached/csl/scanner.h: libmemcached/csl/scanner.cc
 
-.LOW_RESOLUTION_TIME: libmemcached/csl/parser.cc
+.LOW_RESOLUTION_TIME: libmemcached/csl/scanner.cc
 libmemcached/csl/scanner.cc: libmemcached/csl/scanner.l libmemcached/csl/parser.yy
 	$(AM_V_GEN)$(LEX) $<

--- a/libmemcached/csl/parser.am
+++ b/libmemcached/csl/parser.am
@@ -7,10 +7,17 @@ EXTRA_DIST+= libmemcached/csl/scanner.l
 
 libmemcached/csl/parser.h: libmemcached/csl/parser.cc
 
+# This makefile is incompatible with new versions of bison. This means that running the rules for parser.cc or scanner.cc 
+# will break the build. Instead of just removing the rule, we force make to use low resolution (i.e nearest second) 
+# timestmaps. This means that the targets are not regenerated after an initial checkout, but they are if someone 
+# actually changes any of the dependencies. 
+
+.LOW_RESOLUTION_TIME: libmemcached/csl/parser.cc
 libmemcached/csl/parser.cc: libmemcached/csl/parser.yy libmemcached/csl/scanner.l libmemcached/csl/scanner.h
 	$(AM_V_YACC)$(am__skipyacc) $(YACC) $(YLFLAGS) $(AM_YFLAGS) -o $@ $<
 
 libmemcached/csl/scanner.h: libmemcached/csl/scanner.cc
 
+.LOW_RESOLUTION_TIME: libmemcached/csl/parser.cc
 libmemcached/csl/scanner.cc: libmemcached/csl/scanner.l libmemcached/csl/parser.yy
 	$(AM_V_GEN)$(LEX) $<


### PR DESCRIPTION
Ellie, I have got to the bottom of why libmemcached doesn't build reliably on 14.04. 

The problem is that libmemcached uses a tool called bison to generate some parsing code. This parsing code is also checked in to libmemcached. 

On 12.04 we use bison 2.5 which genenerates the same code as is checked in. So it doesn't matter if we regenerate the code during the build, as we get the same answer. On 14.04 we use bison 3. This does not generate the same code as is checked in (in fact it generates code that doesn't compile), so running it breaks the build. 

The reason the build works *sometimes* on 14.04 is that make uses file timestamps to determine whether to regenerate the parsing code, and these are dependent on the time was when git checked the files out.This is not the same each time, so sometimes makes decides to regenerate the parsing code, and the build breaks.

I have a fix that fixes this issue. It is to force make to  low resolution timestamps for the parser output files. This causes make to think the files are up-to-date so it doesn't rebuild them. 

Tested by:

* cloning clearwater-fv-test and checking libmemcached build sucessfully. I did this 10 times and it worked all the time. 
* running make 10 times in the libmemcached submodule, and checking it succeeded each time. 
* checking that clearwater-fv-test runs cleanly afterwards. 

(Note I'm pulling this into you 14.04 fixes branch)